### PR TITLE
[Fix] Update deprecated function

### DIFF
--- a/classification/main.py
+++ b/classification/main.py
@@ -64,7 +64,7 @@ def main(args):
         model = MInterface(**vars(args))
     else:
         model = MInterface(**vars(args))
-        args.resume_from_checkpoint = load_path
+        args.ckpt_path = load_path
 
     # # If you want to change the logger's saving folder
     # logger = TensorBoardLogger(save_dir='kfold_log', name=args.log_dir)

--- a/special/kfold/main.py
+++ b/special/kfold/main.py
@@ -64,7 +64,7 @@ def main(args):
         model = MInterface(**vars(args))
     else:
         model = MInterface(**vars(args))
-        args.resume_from_checkpoint = load_path
+        args.ckpt_path = load_path
 
     # If you want to change the logger's saving folder
     logger = TensorBoardLogger(save_dir='kfold_log', name=args.log_dir)

--- a/super-resolution/main.py
+++ b/super-resolution/main.py
@@ -62,7 +62,7 @@ def main(args):
         model = MInterface(**vars(args))
     else:
         model = MInterface(**vars(args))
-        args.resume_from_checkpoint = load_path
+        args.ckpt_path = load_path
 
     args.callbacks = load_callbacks()
     trainer = Trainer.from_argparse_args(args)


### PR DESCRIPTION
Paste from official document
![image](https://user-images.githubusercontent.com/88025855/209165529-e8e6fd0f-2c26-43ab-8afe-494d1a624a31.png)

the `resume_from_checkpoint` is deprecated in v1.5 and will be removed in v2.0. Now we can use `trainer.fit(ckpt_path="some/path/to/my_checkpoint.ckpt")` instead.
